### PR TITLE
fix: 修复移动端sidebar初始状态可被点击的问题

### DIFF
--- a/styles/mobile.styl
+++ b/styles/mobile.styl
@@ -1,3 +1,6 @@
+.theme-main
+  min-height: 100vh;
+  overflow: auto;
 @media (max-width: $MQNarrow)
   .theme-palette
     display flex


### PR DESCRIPTION
问题：初始化未有文章或文章较少时，红框部分可被点击。（PS: 如下图，为了展示已将.theme-sidebar的opacity属性移除。）

![image](https://user-images.githubusercontent.com/25891481/111939220-a2a94900-8b06-11eb-9120-27ac7dbd8826.png)

解决方案：把.theme-main容器的默认高度占满屏幕。
